### PR TITLE
Feat: Install plugin from local path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# kbn-shoehorn changelog
+
+## v0.3.0
+
+- Add support for installing from a directory
+
+## v0.2.0
+
+- Add interative mode (uses `-y` flag)
+- Add `--branch` flag to specify the desired repo branch on the command line
+
+## v0.1.1
+
+- Typos
+- Don't change package version, always set `kibana.version`
+
+## v0.1.0
+
+- Initial release, allowing plugin installation from repo url
+- Re-write plugin path to match name
+- Re-write plugin version to match Kibana target

--- a/README.md
+++ b/README.md
@@ -21,10 +21,18 @@ Simply run `kbn-shoehorn` from the root of your Kibana path, and follow the prom
 
 ### Specify the plugin inline
 
-You can optionally pass the username/repo as the first argument as well to skip the first question:
+You can optionally pass the username/repo as the first argument as well to skip the first question.
 
 ```
 kbn-shoehorn snuids/Elastic-5.0-Country-Map-Visualizer
+```
+
+### Load plugin from local path
+
+If you need to install a plugin from your machine, you can use the `-f` flag, passing it the path to the plugin. Currently only directories are supported.
+
+```
+kbn-shoehorn -f ~/Download/enhanced_tilemap/
 ```
 
 ### Non Interactive Options

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "download-git-repo": "^1.0.1",
     "inquirer": "^3.2.0",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "ncp": "^2.0.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,29 @@
 /* eslint no-console: 0 */
 const questions = require('./questions');
 const download = require('./download');
+const loadFile = require('./load_file');
 const setVersion = require('./set_version');
 const movePlugin = require('./move_plugin');
 const depInstall = require('./dep_install');
 
+function getPlugin(props) {
+  if (typeof props.filePath === 'string') return loadFile(props.filePath, props.targetPath);
+  return download.repo(props.url, props.branch, props.targetPath);
+}
+
 questions.prompt()
 .then((answers) => {
   // get dirname from the last part of the url name
+  const pluginName = answers.url ? answers.url.split('/').reverse()[0] : '';
+
   const props = Object.assign({
-    targetPath: `${answers.kibanaPath}/plugins/${answers.url.split('/').reverse()[0]}`,
+    targetPath: `${answers.kibanaPath}/plugins/${pluginName}`,
   }, answers);
 
-  return download.repo(props.url, props.branch, props.targetPath)
-  .then(() => {
-    if (props.setVersion) setVersion(props.targetPath, props.kibanaPath);
-    return (props.setPath) ? movePlugin(props.targetPath).targetPath : props.targetPath;
+  return getPlugin(props)
+  .then((targetPath) => {
+    if (props.setVersion) setVersion(targetPath, props.kibanaPath);
+    return (props.setPath) ? movePlugin(targetPath).targetPath : targetPath;
   })
   .then((targetPath) => {
     depInstall(targetPath);

--- a/src/load_file.js
+++ b/src/load_file.js
@@ -1,0 +1,47 @@
+const { statSync } = require('fs');
+const { parse, join } = require('path');
+const ncp = require('ncp').ncp;
+const { readJson } = require('./json_file');
+
+function copyPath(filePath, targetPath) {
+  return new Promise((resolve, reject) => {
+    try {
+      // make sure a package.json file exists
+      const pluginPkgFile = join(filePath, 'package.json');
+      const { name } = readJson(pluginPkgFile);
+      const pluginTarget = join(targetPath, name);
+
+      ncp(filePath, pluginTarget, (err) => {
+        if (err) reject(err);
+        else resolve(pluginTarget);
+      });
+    } catch (e) {
+      if (e.code === 'ENOENT') reject(new Error('Plugin package.json not found'));
+      else reject(e);
+    }
+  });
+}
+
+module.exports = function loadFile(filePath, targetPath) {
+  return new Promise((resolve, reject) => {
+    try {
+      const stat = statSync(filePath);
+      if (stat.isFile()) {
+        const { ext } = parse(filePath);
+
+        if (ext !== '.zip') {
+          reject(`Plugin must be a .zip file, ${ext} is not supported`);
+          return;
+        }
+
+        reject('Sorry, unpacking zip files is not currently supported');
+      } else if (stat.isDirectory()) {
+        copyPath(filePath, targetPath).then(resolve).catch(reject);
+      } else {
+        reject(`Path must be a file or directory: ${filePath}`);
+      }
+    } catch (e) {
+      reject(e);
+    }
+  });
+};

--- a/src/questions.js
+++ b/src/questions.js
@@ -23,6 +23,10 @@ function nonInteractive() {
   return Boolean(argv.y);
 }
 
+function loadFromFile() {
+  return argv.f && (typeof argv.f !== 'boolean') && argv.f.length;
+}
+
 exports.values = [
   {
     name: 'kibanaPath',
@@ -34,14 +38,14 @@ exports.values = [
   {
     name: 'url',
     message: 'The plugin username/repo:',
-    when: () => !validPluginRepo(pluginName()),
+    when: () => !loadFromFile() && !validPluginRepo(pluginName()),
     validate: validPluginRepo,
   },
   {
     name: 'branch',
     message: 'Repo branch:',
     default: 'master',
-    when: () => !argv.branch && !nonInteractive(),
+    when: () => !loadFromFile() && !argv.branch && !nonInteractive(),
   },
   {
     name: 'setVersion',
@@ -64,6 +68,7 @@ exports.prompt = () => inquirer.prompt(exports.values)
   kibanaPath: defaultKibanaPath(),
   url: pluginName(),
   branch: argv.branch || 'master',
+  filePath: argv.f,
   setVersion: true,
   setPath: true,
 }, ans));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,6 +1107,10 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+
 normalize-package-data@^2.3.2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.8.tgz#d819eda2a9dedbd1ffa563ea4071d936782295bb"


### PR DESCRIPTION
Part of #3 

This PR adds a `-f` flag which can be used to install a plugin from a local path. Right now, the plugin must be in a directory, so zip files are not supported. I plan to add zip support in another PR.

As with installing from a repo path, kbn-shoehorn will still rename the path and set the `kibana.version` in the package based on user inputs (or the unattended `-y` flag).