### PR TITLE
Feat: install from zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v0.3.0
 
-- Add support for installing from a directory
+- Add support for installing from a local directory
+- Add support for installing from a local zip file
 
 ## v0.2.0
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ kbn-shoehorn snuids/Elastic-5.0-Country-Map-Visualizer
 
 ### Load plugin from local path
 
-If you need to install a plugin from your machine, you can use the `-f` flag, passing it the path to the plugin. Currently only directories are supported.
+If you need to install a plugin from your machine, you can use the `-f` flag, passing it the path to the plugin. If you have a zip file, that can be used as well.
 
 ```
-kbn-shoehorn -f ~/Download/enhanced_tilemap/
+kbn-shoehorn -f ~/Downloads/kibana/enhanced_tilemap/
+
+# or from a zip file
+kbn-shoehorn -f ~/Downloads/health_metric_vis-5.5.0.zip
 ```
 
 ### Non Interactive Options

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
   "homepage": "https://github.com/w33ble/kbn-shoehorn",
   "dependencies": {
     "download-git-repo": "^1.0.1",
+    "extract-zip": "^1.6.5",
     "inquirer": "^3.2.0",
     "minimist": "^1.2.0",
-    "ncp": "^2.0.0"
+    "ncp": "^2.0.0",
+    "temp-dir": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/w33ble/kbn-shoehorn",
   "dependencies": {
+    "@w33ble/extract-zip": "^1.6.6",
     "download-git-repo": "^1.0.1",
-    "extract-zip": "^1.6.5",
     "inquirer": "^3.2.0",
     "minimist": "^1.2.0",
     "ncp": "^2.0.0",

--- a/src/load_file.js
+++ b/src/load_file.js
@@ -1,26 +1,40 @@
-const { statSync } = require('fs');
+const { statSync, readdirSync } = require('fs');
 const { parse, join } = require('path');
 const ncp = require('ncp').ncp;
 const tempDir = require('temp-dir');
 const extract = require('extract-zip');
 const { readJson } = require('./json_file');
 
+// paths to ignore when attempting to traverse into plugin
+const ignorePaths = [
+  '.DS_Store',
+];
+
+function readPackageName(dirPath) {
+  try {
+    const pluginPkgFile = join(dirPath, 'package.json');
+    return readJson(pluginPkgFile).name;
+  } catch (e) {
+    return null;
+  }
+}
+
 function copyPath(filePath, targetPath) {
   return new Promise((resolve, reject) => {
-    try {
-      // make sure a package.json file exists
-      const pluginPkgFile = join(filePath, 'package.json');
-      const { name } = readJson(pluginPkgFile);
-      const pluginTarget = join(targetPath, name);
+    const pluginName = readPackageName(filePath);
 
-      ncp(filePath, pluginTarget, (err) => {
-        if (err) reject(err);
-        else resolve(pluginTarget);
-      });
-    } catch (e) {
-      if (e.code === 'ENOENT') reject(new Error('Plugin package.json not found'));
-      else reject(e);
+    // make sure a package.json file exists
+    if (!pluginName) {
+      reject(new Error('Failed to read name from plugin'));
+      return;
     }
+
+    const pluginTarget = join(targetPath, pluginName);
+
+    ncp(filePath, pluginTarget, (err) => {
+      if (err) reject(err);
+      else resolve(pluginTarget);
+    });
   });
 }
 
@@ -35,8 +49,30 @@ function unpackZip(filePath, targetPath) {
     }
 
     extract(filePath, { dir: unpackTarget }, (err) => {
-      if (err) reject(err);
-      else resolve(copyPath(unpackTarget, targetPath));
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      // look for name in package.json, traverse if only one path is found
+      function getPluginPath(dirPath) {
+        const pluginName = readPackageName(dirPath);
+
+        if (!pluginName) {
+          const paths = readdirSync(dirPath).filter(path => ignorePaths.indexOf(path) === -1);
+          if (paths.length !== 1) throw new Error(`Plugin not found: ${filePath}`);
+
+          const deepDirPath = join(dirPath, paths[0]);
+          const stat = statSync(deepDirPath);
+          if (!stat.isDirectory()) throw new Error(`Plugin not found: ${filePath}`);
+
+          return getPluginPath(deepDirPath);
+        }
+
+        return dirPath;
+      }
+
+      resolve(copyPath(getPluginPath(unpackTarget), targetPath));
     });
   });
 }

--- a/src/load_file.js
+++ b/src/load_file.js
@@ -36,7 +36,7 @@ module.exports = function loadFile(filePath, targetPath) {
 
         reject('Sorry, unpacking zip files is not currently supported');
       } else if (stat.isDirectory()) {
-        copyPath(filePath, targetPath).then(resolve).catch(reject);
+        resolve(copyPath(filePath, targetPath));
       } else {
         reject(`Path must be a file or directory: ${filePath}`);
       }

--- a/src/load_file.js
+++ b/src/load_file.js
@@ -27,7 +27,7 @@ function copyPath(filePath, targetPath) {
 function unpackZip(filePath, targetPath) {
   return new Promise((resolve, reject) => {
     const { ext, name } = parse(filePath);
-    const unpackTarget = join(tempDir, name);
+    const unpackTarget = join(tempDir, name, String((new Date()).getTime())); // unique temp unzip path
 
     if (ext !== '.zip') {
       reject(`Plugin must be a .zip file, ${ext} is not supported`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,7 +228,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.2:
+concat-stream@1.6.0, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -634,6 +634,15 @@ external-editor@^2.0.4:
     iconv-lite "^0.4.17"
     jschardet "^1.4.2"
     tmp "^0.0.31"
+
+extract-zip@^1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.5.tgz#99a06735b6ea20ea9b705d779acffcc87cff0440"
+  dependencies:
+    concat-stream "1.6.0"
+    debug "2.2.0"
+    mkdirp "0.5.0"
+    yauzl "2.4.1"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -1081,6 +1090,12 @@ minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+mkdirp@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
+  dependencies:
+    minimist "0.0.8"
+
 mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -1510,6 +1525,10 @@ tar-stream@^1.5.2:
     readable-stream "^2.0.0"
     xtend "^4.0.0"
 
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -1603,6 +1622,12 @@ write@^0.2.1:
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  dependencies:
+    fd-slicer "~1.0.1"
 
 yauzl@^2.4.2:
   version "2.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@w33ble/extract-zip@^1.6.6":
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/@w33ble/extract-zip/-/extract-zip-1.6.6.tgz#fa85becbfa75f538c2af4355774aacceb96733cf"
+  dependencies:
+    concat-stream "^1.6.0"
+    debug "^2.6.8"
+    mkdirp "^0.5.1"
+    yauzl "^2.8.0"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -228,7 +237,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0, concat-stream@^1.5.2:
+concat-stream@^1.5.2, concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -266,7 +275,7 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@^2.1.1, debug@^2.2.0:
+debug@^2.1.1, debug@^2.2.0, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -634,15 +643,6 @@ external-editor@^2.0.4:
     iconv-lite "^0.4.17"
     jschardet "^1.4.2"
     tmp "^0.0.31"
-
-extract-zip@^1.6.5:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.5.tgz#99a06735b6ea20ea9b705d779acffcc87cff0440"
-  dependencies:
-    concat-stream "1.6.0"
-    debug "2.2.0"
-    mkdirp "0.5.0"
-    yauzl "2.4.1"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -1089,12 +1089,6 @@ minimist@0.0.8:
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  dependencies:
-    minimist "0.0.8"
 
 mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -1623,13 +1617,7 @@ xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-yauzl@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
-  dependencies:
-    fd-slicer "~1.0.1"
-
-yauzl@^2.4.2:
+yauzl@^2.4.2, yauzl@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.8.0.tgz#79450aff22b2a9c5a41ef54e02db907ccfbf9ee2"
   dependencies:


### PR DESCRIPTION
Add the ability to install a plugin from a local zip file. Work much the same way that installing from a local path does, except you don't need to unpack the zip file if that's what you have. 